### PR TITLE
Fixes for the game

### DIFF
--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "game"
+name = "squink_splash"
 version = "0.1.0"
-authors = ["[your_name] <[your_email]>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]

--- a/game/lib.rs
+++ b/game/lib.rs
@@ -72,6 +72,7 @@ mod squink_splash {
         gas_used: u64,
         /// TODO: This is not used yet.
         storage_used: u32,
+        /// This is per block. We could allow more than one turn per block.
         last_turn: u32,
     }
 
@@ -211,8 +212,10 @@ mod squink_splash {
         ///
         /// Each player can only make one turn per block. If the contract panics or fails
         /// to return the proper result the turn of forfeited and the gas usage is still recorded.
+        ///
+        /// The `data` argument is passed verbatim to the player contract.
         #[ink(message)]
-        pub fn submit_turn(&mut self, id: AccountId) {
+        pub fn submit_turn(&mut self, id: AccountId, data: Vec<u8>) {
             assert!(
                 self.is_running(),
                 "The game does not accept turns right now."
@@ -239,7 +242,7 @@ mod squink_splash {
             // We need to call with reentrancy enabled to allow those contracts to query us.
             let call = build_call::<DefaultEnvironment>()
                 .call_type(Call::new().callee(player.id))
-                .exec_input(ExecutionInput::new(Selector::from([0x00; 4])))
+                .exec_input(ExecutionInput::new(Selector::from([0x00; 4])).push_arg(data))
                 .call_flags(CallFlags::default().set_allow_reentry(true))
                 .returns::<(u32, u32)>();
 

--- a/game/lib.rs
+++ b/game/lib.rs
@@ -321,7 +321,9 @@ mod squink_splash {
             }
 
             players.into_iter().map(move |p| {
-                let score = scores[&p.id]
+                let score = scores
+                    .get(&p.id)
+                    .unwrap_or(&0)
                     .saturating_sub(p.gas_used)
                     .saturating_sub(p.storage_used.into());
                 (p, score)

--- a/game/lib.rs
+++ b/game/lib.rs
@@ -75,6 +75,18 @@ mod squink_splash {
         last_turn: u32,
     }
 
+    /// A player attempted to make a turn.
+    #[ink(event)]
+    pub struct TurnTaken {
+        /// The player that attempted the turn.
+        player: AccountId,
+        /// The field that was painted by the player.
+        ///
+        /// This is `None` if the turn failed. This will happen if the player's contract
+        /// fails to return a proper turn.
+        turn: Option<(u32, u32)>,
+    }
+
     impl SquinkSplash {
         /// Create a new game.
         #[ink(constructor)]
@@ -235,6 +247,11 @@ mod squink_splash {
                 // Just overpaint. Overpainting is the best case cause it steals points.
                 self.board.insert(self.idx(x, y), &player.id);
             }
+
+            self.env().emit_event(TurnTaken {
+                player: player.id,
+                turn: turn.ok(),
+            });
 
             self.players.set(&players);
         }

--- a/game/lib.rs
+++ b/game/lib.rs
@@ -118,6 +118,10 @@ mod squink_splash {
         #[ink(message)]
         pub fn start_game(&mut self, rounds: u32) {
             assert_eq!(self.admin, self.env().caller(), "Only admin can call this.");
+            assert!(
+                matches!(self.state, State::Forming),
+                "Game already started."
+            );
             let players = self.players();
             assert!(!players.is_empty(), "You need at least one player.");
             let start_block = self.env().block_number();

--- a/game/lib.rs
+++ b/game/lib.rs
@@ -231,10 +231,8 @@ mod squink_splash {
         ///
         /// Each player can only make one turn per block. If the contract panics or fails
         /// to return the proper result the turn of forfeited and the gas usage is still recorded.
-        ///
-        /// The `data` argument is passed verbatim to the player contract.
         #[ink(message)]
-        pub fn submit_turn(&mut self, id: AccountId, data: Vec<u8>) {
+        pub fn submit_turn(&mut self, id: AccountId) {
             assert!(
                 self.is_running(),
                 "The game does not accept turns right now."
@@ -261,7 +259,7 @@ mod squink_splash {
             // We need to call with reentrancy enabled to allow those contracts to query us.
             let call = build_call::<DefaultEnvironment>()
                 .call_type(Call::new().callee(player.id))
-                .exec_input(ExecutionInput::new(Selector::from([0x00; 4])).push_arg(data))
+                .exec_input(ExecutionInput::new(Selector::from([0x00; 4])))
                 .call_flags(CallFlags::default().set_allow_reentry(true))
                 .returns::<(u32, u32)>();
 

--- a/game/lib.rs
+++ b/game/lib.rs
@@ -78,14 +78,16 @@ mod squink_splash {
         /// Create a new game.
         #[ink(constructor)]
         pub fn new(dimensions: (u32, u32), buy_in: Balance) -> Self {
-            Self {
+            let mut ret = Self {
                 admin: Self::env().caller(),
                 state: State::Forming,
                 board: Default::default(),
                 dimensions,
                 players: Default::default(),
                 buy_in,
-            }
+            };
+            ret.players.set(&Vec::new());
+            ret
         }
 
         /// When the game is in finished the contract can be deleted by the admin.
@@ -142,7 +144,7 @@ mod squink_splash {
         }
 
         /// Add a new player to the game. Only allowed while the game has not started.
-        #[ink(message)]
+        #[ink(message, payable)]
         pub fn register_player(&mut self, id: AccountId, name: String) {
             assert!(matches!(self.state, State::Forming));
             assert!(name.len() <= PLAYER_NAME_LIMIT);
@@ -220,7 +222,9 @@ mod squink_splash {
         /// List of all players sorted by id.
         #[ink(message)]
         pub fn players(&self) -> Vec<Player> {
-            self.players.get().expect("Why does Lazy return Option?")
+            self.players
+                .get()
+                .expect("Initial value is set in constructor.")
         }
 
         /// List of of all players (sorted by id) and their current scores.

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -2,9 +2,6 @@
 
 #[ink::contract]
 mod player {
-    use ink::prelude::vec::Vec;
-    use scale::Decode;
-
     #[ink(storage)]
     pub struct Player {}
 
@@ -20,8 +17,8 @@ mod player {
         /// `&mut self` is important, so that players can retain state if
         /// they want to.
         #[ink(message, selector = 0)]
-        pub fn your_turn(&mut self, data: Vec<u8>) -> (u32, u32) {
-            Decode::decode(&mut data.as_ref()).unwrap()
+        pub fn your_turn(&mut self) -> (u32, u32) {
+            (10, 10)
         }
     }
 }

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -2,6 +2,9 @@
 
 #[ink::contract]
 mod player {
+    use ink::prelude::vec::Vec;
+    use scale::Decode;
+
     #[ink(storage)]
     pub struct Player {}
 
@@ -17,8 +20,8 @@ mod player {
         /// `&mut self` is important, so that players can retain state if
         /// they want to.
         #[ink(message, selector = 0)]
-        pub fn your_turn(&mut self) -> (u32, u32) {
-            (10, 10)
+        pub fn your_turn(&mut self, data: Vec<u8>) -> (u32, u32) {
+            Decode::decode(&mut data.as_ref()).unwrap()
         }
     }
 }


### PR DESCRIPTION
- Fixed bugs
- Make scores per field relative to the average consumed gas of all players per round
- Remove admin: We can get away with being permission less
- Add error texts to all asserts
- Added an event when turns are taken

I think we can get away with this single event. All other things (scoreboard, field layout) should just be refreshed every block from the getters instead of listening for events. But the individual turns are more easily learned from events.